### PR TITLE
Version 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # lmc-api-util Changelog
 
-## 1.2.0
+## 1.2.1
 > Released 9 Nov 2019
 
 - Fixed `calcPaging()` to return only integer values in paging object, even if passed in strings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # lmc-api-util Changelog
 
 ## 1.2.0
+> Released 9 Nov 2019
+
+- Fixed `calcPaging()` to return only integer values in paging object, even if passed in strings
+
+## 1.2.0
 > Released 21 Oct 2019
 
 - Added `calcPaging()` for generating paging

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ simply pass `req.query`. Recognized values are:
 - `options` (optional) - other options for paging:
    - `maxPageSize` - maximum requestable page size. Defaults to 200
 
-Return a single object with the following values:
+Return a single object with the following values (all as integers):
 
 - `page` - current page of data
 - `pageSize` - number of objects per page

--- a/index.js
+++ b/index.js
@@ -120,15 +120,18 @@ const calcPaging = function(params, options) {
         page: 1
     });
 
+    paging.page = _.toSafeInteger(paging.page);
+    paging.pageSize = _.toSafeInteger(paging.pageSize);
+
     if(paging.pageSize > opts.maxPageSize) {
         paging.pageSize = opts.maxPageSize;
     }
 
-    if(paging.pageSize < 1) {
+    if(paging.pageSize === false || paging.pageSize < 1) {
         paging.pageSize = DEFAULT_PAGE_SIZE;
     }
 
-    if(paging.page < 1) {
+    if(paging.page === false || paging.page < 1) {
         paging.page = 1;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lmc-api-util",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmc-api-util",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Stateless helper functions for implementing RESTful APIs in express",
   "main": "index.js",
   "scripts": {

--- a/test/other-test.js
+++ b/test/other-test.js
@@ -148,5 +148,29 @@ describe('lmc-api-util - other functions', function() {
 
             done();
         });
+        it('should convert strings to integers', function(done) {
+            const paging = api.calcPaging({
+                page: '2',
+                pageSize: '75'
+            });
+
+            expect(paging.page).to.equal(2);
+            expect(paging.pageSize).to.equal(75);
+            expect(paging.offset).to.equal(75);
+            expect(paging.limit).to.equal(75);
+
+            done();
+        });
+        it('should ignore bad string values', function(done) {
+            const paging = api.calcPaging({
+                page: 'foo',
+                pageSize: 'bar'
+            });
+
+            expect(paging.page).to.equal(1);
+            expect(paging.pageSize).to.equal(50);
+
+            done();
+        });
     });
 });


### PR DESCRIPTION
## 1.2.1
> Released 9 Nov 2019

- Fixed `calcPaging()` to return only integer values in paging object, even if passed in strings
