### PR TITLE
Version/1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # lmc-api-util Changelog
 
 ## 1.2.3
-> Released XX XXX 2021
+> Released 9 Jun 2021
 
-- Allowed limit and offset to be passed in directly for calcPaging()
+- Allowed `limit` and `offset` to be passed in directly for `calcPaging()`
 - Merged in dependabot fixes
 
 ## 1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # lmc-api-util Changelog
 
+## 1.2.3
+> Released XX XXX 2021
+
 ## 1.2.2
 > Released 6 Apr 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 ## 1.2.3
 > Released XX XXX 2021
 
+- Allowed limit and offset to be passed in directly for calcPaging()
+- Merged in dependabot fixes
+
 ## 1.2.2
 > Released 6 Apr 2020
 
-- Updated dependencies to fix vulerabilities
+- Updated dependencies to fix vulnerabilities
 
 ## 1.2.1
 > Released 9 Nov 2019

--- a/README.md
+++ b/README.md
@@ -214,12 +214,16 @@ app.get('/api/check', function(req, res) {
 ### calcPaging(params, options)
 
 Generates a well-defined object that can be used for paging when looking up
-data. Handles omitted parameters and calculates offset and limit values.
+data. Handles omitted parameters and calculates offset and limit values. `limit`
+and `offset` can also be passed in directly, but will be overriden if `page` or
+`pageSize` are provided.
 
 - `params` (required) - array or object of provided parameters. Usually can
 simply pass `req.query`. Recognized values are:
    - `page` - current page. Defaults to 1
    - `pageSize` - numer of objects per page. Defaults to 50, but is limited by `maxPageSize` below
+   - `limit` - can be set directly if `page` and `pageSize` are omitted
+   - `offset` - can be set directly if `page` and `pageSize` are omitted
 - `options` (optional) - other options for paging:
    - `maxPageSize` - maximum requestable page size. Defaults to 200
 
@@ -246,6 +250,10 @@ var app = express();
 //     {"result":"OK","message":"Paging!","page":4,"pageSize":100,"offset":300,"limit":100} 
 // Call /api/paging?page=5&pageSize=999 returns:
 //     {"result":"OK","message":"Paging!","page":4,"pageSize":200,"offset":400,"limit":200} 
+// Call /api/paging?limit=5&offset=10 returns:
+//     {"result":"OK","message":"Paging!","page":2,"pageSize":5,"offset":10,"limit":5} 
+// Call /api/paging?limit=5&offset=10&page=3&pageSize=12 returns:
+//     {"result":"OK","message":"Paging!","page":3,"pageSize":12,"offset":24,"limit":12} 
 
 app.get('/api/paging', function(req, res) {
     const paging = api.calcPaging(req.query);

--- a/index.js
+++ b/index.js
@@ -120,6 +120,20 @@ const calcPaging = function(params, options) {
         page: 1
     });
 
+    // limit and offset can be passed in directly, in which case we use them
+    // to calculate page and return it
+    if(params.offset && params.limit && !params.page && !params.pageSize) {
+        paging.offset = _.toSafeInteger(params.offset);
+        paging.limit = _.toSafeInteger(params.limit);
+
+        if(paging.offset && paging.limit) {
+            paging.pageSize = paging.limit;
+            paging.page = Math.floor(params.offset / paging.limit);
+
+            return paging;
+        }
+    }
+
     paging.page = _.toSafeInteger(paging.page);
     paging.pageSize = _.toSafeInteger(paging.pageSize);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lmc-api-util",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmc-api-util",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Stateless helper functions for implementing RESTful APIs in express",
   "main": "index.js",
   "scripts": {

--- a/test/other-test.js
+++ b/test/other-test.js
@@ -172,5 +172,35 @@ describe('lmc-api-util - other functions', function() {
 
             done();
         });
+        it('should allow offset and limit to be directly passed', function(done) {
+            const paging = api.calcPaging({
+                offset: 24,
+                limit: 12
+            });
+
+            expect(paging.offset).to.equal(24);
+            expect(paging.limit).to.equal(12);
+            expect(paging.pageSize).to.equal(12);
+
+            // Best guess of this value
+            expect(paging.page).to.equal(2);
+
+            done();
+        });
+        it('should ignore offset and limit if pageSize and page are also passed in', function(done) {
+            const paging = api.calcPaging({
+                offset: 24,
+                limit: 12,
+                page: 3,
+                pageSize: 25
+            });
+
+            expect(paging.page).to.equal(3);
+            expect(paging.pageSize).to.equal(25);
+            expect(paging.offset).to.equal(50);
+            expect(paging.limit).to.equal(25);
+
+            done();
+        });
     });
 });


### PR DESCRIPTION
## 1.2.3
> Released 9 Jun 2021
- Allowed `limit` and `offset` to be passed in directly for `calcPaging()`
- Merged in dependabot fixes
